### PR TITLE
wrap DOM query on a jquery ready call ensuring  DOM is stable.

### DIFF
--- a/grails-app/taglib/uk/co/desirableobjects/ajaxuploader/AjaxUploaderTagLib.groovy
+++ b/grails-app/taglib/uk/co/desirableobjects/ajaxuploader/AjaxUploaderTagLib.groovy
@@ -64,7 +64,8 @@ class AjaxUploaderTagLib {
             </div>
         """
 
-        out << g.javascript([:], """
+        out << g.javascript([:], '$(document).ready( function() {' +
+         """
             var au_${currentUploaderUid} = new qq.FileUploader({
             element: document.getElementById('au-${currentUploaderUid}'),
             action: '${url}'"""+
@@ -76,6 +77,7 @@ class AjaxUploaderTagLib {
 
         """
             });
+        });
         """)
 
         reset()


### PR DESCRIPTION
Had an issue using this plugin on a heavy html page using Chrome 31.0.1650.57. The call "document.getElementById('au-${currentUploaderUid}'" was returning null. Waiting for the DOM to stabilize using jquery ready event solved the problem.
